### PR TITLE
allow using shared libraries

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -4,6 +4,7 @@ go:
 repository:
     path: github.com/prometheus-community/postgres_exporter
 build:
+    static: false
     binaries:
         - name: postgres_exporter
           path: ./cmd/postgres_exporter


### PR DESCRIPTION
The -static flag forces the linker to accept only static libraries and not any shared libraries. we want to make it dynamic so that it can support fips.