### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for postgres-exporter-globalhub-1-5

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -17,7 +17,8 @@ LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernet
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/postgres_exporter"
+LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.5::el9"
 LABEL version="release-1.5"
 LABEL summary="multicluster global hub postgres exporter"
 LABEL io.openshift.expose-services=""


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
