### PR TITLE
Replace slack-member-id with slack-group-id in .tekton files for release 1.6

### DIFF
--- a/.tekton/postgres-exporter-globalhub-1-6-push.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-6-push.yaml
@@ -50,7 +50,7 @@ spec:
     value: "slack-notify-webhook"
   - name: slack-webhook-url-secret-key
     value: "slack-webhook-url"
-  - name: slack-member-id
+  - name: slack-group-id
     # Will mention the user in the slack message when the pipeline run failed; this is not required.
     # Please make sure replace the value with component owner's slack member id.
     value: "S09JCE3DF9N"


### PR DESCRIPTION
## Summary
- Replace slack-member-id with slack-group-id in Tekton pipeline configuration for release 1.6 (release-2.15)
- Update postgres-exporter-globalhub-1-6-push.yaml to use the new parameter name
- This aligns with updated Slack notification requirements

## Test plan
- [x] Verify the .tekton file syntax is correct
- [x] Confirm the change only affects the parameter name
- [ ] Test pipeline execution with new parameter

🤖 Generated with [Claude Code](https://claude.ai/code)