### PR TITLE
Update release-2.16 postgres_exporter configuration

### DIFF
--- a/.tekton/postgres-exporter-globalhub-1-7-pull-request.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-7-pull-request.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-2.15"
+      == "release-2.16"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-6
-    appstudio.openshift.io/component: postgres-exporter-globalhub-1-6
+    appstudio.openshift.io/application: release-globalhub-1-7
+    appstudio.openshift.io/component: postgres-exporter-globalhub-1-7
     pipelines.appstudio.openshift.io/type: build
-  name: postgres-exporter-globalhub-1-6-on-pull-request
+  name: postgres-exporter-globalhub-1-7-on-pull-request
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-6:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-7:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -53,7 +53,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-6
+    serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-7
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/postgres-exporter-globalhub-1-7-push.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-7-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-2.15"
+      == "release-2.16"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-globalhub-1-6
-    appstudio.openshift.io/component: postgres-exporter-globalhub-1-6
+    appstudio.openshift.io/application: release-globalhub-1-7
+    appstudio.openshift.io/component: postgres-exporter-globalhub-1-7
     pipelines.appstudio.openshift.io/type: build
-  name: postgres-exporter-globalhub-1-6-on-push
+  name: postgres-exporter-globalhub-1-7-on-push
   namespace: acm-multicluster-glo-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-6:{{revision}}
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-1-7:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -44,7 +44,7 @@ spec:
   - name: send-slack-notification
     value: "true"
   - name: konflux-application-name
-    value: "release-globalhub-1-6"
+    value: "release-globalhub-1-7"
   - name: slack-webhook-url-secret-name
     # See details: https://konflux.pages.redhat.com/docs/users/patterns/slack-notifications.html
     value: "slack-notify-webhook"
@@ -64,7 +64,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-6
+    serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-7
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Update release-2.16 postgres_exporter configuration

## Changes

- Rename and update pull-request pipeline for `globalhub-1-7`
- Rename and update push pipeline for `globalhub-1-7`
- Update branch references to `release-2.16`

## Version Mapping

- **ACM**: release-2.16
- **Global Hub**: v1.7.0
- **Postgres tag**: globalhub-1-7
- **Previous release**: release-2.15