### PR TITLE
Upgrade Go version from 1.23 to 1.25.3

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     # This must match .circle/config.yml.
-    version: 1.23
+    version: 1.25
 repository:
     path: github.com/prometheus-community/postgres_exporter
 build:

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.23.2
+go 1.25.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
- Updated Go version from 1.23 to 1.25.3 across the project
- Modified go.mod: 1.23.2 -> 1.25.3
- Modified Containerfile.konflux: rhel_9_1.23 -> rhel_9_1.25
- Modified .promu.yml: 1.23 -> 1.25

## Test plan
- [ ] Verify the build completes successfully with Go 1.25.3
- [ ] Ensure all tests pass with the new Go version
- [ ] Confirm Konflux pipeline builds correctly with updated builder image

🤖 Generated with [Claude Code](https://claude.com/claude-code)