### PR TITLE
Update CPE label and component name for release 1.6

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -11,15 +11,16 @@ RUN promu build --cgo --prefix ./
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster global hub postgres exporter"
+LABEL com.redhat.component="multicluster-globalhub-postgres-exporter"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/postgres_exporter"
-LABEL version="release-1.5"
-LABEL summary="multicluster global hub postgres exporter"
+LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.6::el9"
+LABEL version="release-1.6"
+LABEL summary="multicluster globalhub postgres exporter"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"
 LABEL io.k8s.display-name="multicluster global hub postgres exporter"


### PR DESCRIPTION
## Summary
- Add CPE label: `cpe:/a:redhat:multicluster_globalhub:1.6::el9`
- Update component name from `multicluster global hub postgres exporter` to `multicluster-globalhub-postgres-exporter`
- Update name from `multicluster-global-hub/postgres_exporter` to `multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9`
- Update version from `release-1.5` to `release-1.6`
- Update summary to use `globalhub` instead of `global hub`

## Test plan
- Verify Containerfile.konflux has correct CPE label and component name
- Verify build passes in Konflux

Generated with [Claude Code](https://claude.com/claude-code)