### PR TITLE
chore(KONFLUX-6210): Update CPE label and naming for release 1.7

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -11,14 +11,15 @@ RUN promu build --cgo --prefix ./
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
-LABEL com.redhat.component="multicluster global hub postgres exporter"
+LABEL com.redhat.component="multicluster-globalhub-postgres-exporter-rhel9-container"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.7::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/postgres_exporter"
-LABEL version="release-1.5"
+LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
+LABEL version="release-1.7"
 LABEL summary="multicluster global hub postgres exporter"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
- Add CPE label `cpe:/a:redhat:multicluster_globalhub:1.7::el9` for KONFLUX-6210 compliance
- Update component name to `multicluster-globalhub-postgres-exporter-rhel9-container`
- Update name label to `multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9`
- Update version from `release-1.5` to `release-1.7`

## Context
This change addresses KONFLUX-6210, which requires Clair to have access to name and CPE labels for VEX statement lookups.

See also: release-engineering/rhtap-ec-policy#149

🤖 Generated with [Claude Code](https://claude.com/claude-code)