### PR TITLE
fix: upgrade Go to 1.25.5 to fix CVE-2025-61729

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.19
+go 1.25.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

- Upgrade Go version from 1.19 to 1.25.5 to address CVE-2025-61729
- CVE-2025-61729 is an excessive resource consumption vulnerability in `crypto/x509` when printing error string for host certificate validation
- A malicious certificate can cause quadratic runtime due to unlimited hosts being printed with repeated string concatenation

## Related Jira Issue

- Fixes: https://issues.redhat.com/browse/ACM-28103

## Test plan

- [ ] Verify image builds successfully with Go 1.25.5
- [ ] Run unit tests
- [ ] Verify no regression in functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)