### PR TITLE
fix: upgrade Go to 1.25.7 to fix CVE-2025-61729

### DIFF
--- a/.tekton/postgres-exporter-globalhub-1-4-pull-request.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-4-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common-base.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-4
   workspaces:

--- a/.tekton/postgres-exporter-globalhub-1-4-push.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-4-push.yaml
@@ -47,7 +47,7 @@ spec:
       - name: revision
         value: main 
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common-base.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-4
   workspaces:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
## Related Jira Issue
https://issues.redhat.com/browse/ACM-29294

## Related Jira Issue
https://issues.redhat.com/browse/ACM-29490

## Summary

- Upgrade Go version from 1.25.3 to 1.25.5 to address CVE-2025-61729
- CVE-2025-61729 is an excessive resource consumption vulnerability in `crypto/x509` when printing error string for host certificate validation

## Related Jira Issue

- Fixes: https://issues.redhat.com/browse/ACM-28103

## Test plan

- [ ] Verify image builds successfully with Go 1.25.5
- [ ] Run unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)