### PR TITLE
fix: upgrade Go version from 1.25.3 to 1.25.7

### DIFF
--- a/.tekton/postgres-exporter-globalhub-1-5-pull-request.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-5-pull-request.yaml
@@ -50,7 +50,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common-base.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-5
   workspaces:

--- a/.tekton/postgres-exporter-globalhub-1-5-push.yaml
+++ b/.tekton/postgres-exporter-globalhub-1-5-push.yaml
@@ -48,7 +48,7 @@ spec:
       - name: revision
         value: main
       - name: pathInRepo
-        value: pipelines/common.yaml
+        value: pipelines/common-base.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-postgres-exporter-globalhub-1-5
   workspaces:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
## Summary

- Upgrade Go version from 1.25.3 to 1.25.7 to fix multiple CVEs in Go standard library
- Fixes the following CVEs for multicluster-globalhub-postgres-exporter:
  - **CVE-2025-68121**: Unexpected session resumption in `crypto/tls` (fixed in Go 1.25.7)
  - **CVE-2025-61726**: Memory exhaustion in query parameter parsing in `net/url` (fixed in Go 1.25.6)
  - **CVE-2025-61728**: Excessive CPU consumption when building archive index in `archive/zip` (fixed in Go 1.25.6)
  - **CVE-2025-61729**: Denial of Service due to excessive resource consumption via crafted certificate in `crypto/x509` (fixed in Go 1.25.5)

### Related Jira Issues (Global Hub 1.5)

| CVE | Issue | Title |
|-----|-------|-------|
| CVE-2025-61726 | [ACM-29495](https://issues.redhat.com/browse/ACM-29495) | multicluster-globalhub-postgres-exporter-rhel9: Memory exhaustion in query parameter parsing in net/url [1.5] |
| CVE-2025-61728 | [ACM-29299](https://issues.redhat.com/browse/ACM-29299) | multicluster-globalhub-postgres-exporter-rhel9: Excessive CPU consumption in archive/zip [1.5] |

### Related PRs

- multicluster-global-hub: https://github.com/stolostron/multicluster-global-hub/pull/2326

## Test plan

- [ ] Verify Go version is 1.25.7 in go.mod
- [ ] CI passes with updated Go version

[ACM-29495]: https://redhat.atlassian.net/browse/ACM-29495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-29299]: https://redhat.atlassian.net/browse/ACM-29299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ