### PR TITLE
Update release-2.17 postgres_exporter configuration

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -12,14 +12,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-postgres-exporter-rhel9-container"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.7::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
-LABEL version="release-1.7"
+LABEL version="release-1.8"
 LABEL summary="multicluster global hub postgres exporter"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
Update release-2.17 postgres_exporter configuration

## Changes

- Rename and update pull-request pipeline for `globalhub-1-8`
- Rename and update push pipeline for `globalhub-1-8`
- Update branch references to `release-2.17`
- Update Containerfile.konflux labels (cpe, version)

## Version Mapping

- **ACM**: release-2.17
- **Global Hub**: v1.8.0
- **Postgres tag**: globalhub-1-8
- **Previous release**: release-2.16