### PR TITLE
fix: update name/cpe labels in Containerfile.konflux [multicluster-globalhub-1.3]

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -17,7 +17,8 @@ LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernet
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
-LABEL name="multicluster-global-hub/postgres_exporter"
+LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.3::el9"
 LABEL version="release-1.4"
 LABEL summary="multicluster global hub postgres exporter"
 LABEL io.openshift.expose-services=""

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- bjoydeep
+- birsanv
+
+reviewers:
+- bjoydeep
+- birsanv


### PR DESCRIPTION
## Summary

Backport of KONFLUX-6210 label fixes from `release-2.14` to `release-2.12`.

The Konflux release pipeline `step-enforce-name-label` is failing for `postgres-exporter-globalhub-1-3` because the `name` label uses the old format.

**Error:**
```
Component 'postgres-exporter-globalhub-1-3' name label
('multicluster-global-hub/postgres_exporter')
does not match expected name ('multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9')
```

**Changes to `Containerfile.konflux`:**
| Label | Before | After |
|-------|--------|-------|
| `name` | `multicluster-global-hub/postgres_exporter` | `multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9` |
| `cpe` | _(missing)_ | `cpe:/a:redhat:multicluster_globalhub:1.3::el9` |

Same fix was applied to `release-2.14+` via KONFLUX-6210 but was never backported to `release-2.12`.

Made with [Cursor](https://cursor.com)