### PR TITLE
Add OWNERS file for Prow approval

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- bjoydeep
+- birsanv
+
+reviewers:
+- bjoydeep
+- birsanv
+


### PR DESCRIPTION
## Summary

Add `OWNERS` so Prow `/approve` and Tide can merge PRs on `main`.

Approvers/reviewers match [multicluster-global-hub OWNERS](https://github.com/stolostron/multicluster-global-hub/blob/main/OWNERS) (subset: bjoydeep, birsanv).

Unblocks Mintmaker dependency PR backlog where openshift-ci reported approval against a missing OWNERS file.

## Test plan

- [ ] Merge this PR
- [ ] Re-run `/approve` on open Mintmaker PRs targeting `main` (if any)