### PR TITLE
fix: pin ubi-minimal base for consistent multi-arch RPMs (GH 1.3.4 rc4)

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -8,7 +8,7 @@ ENV BUILD_PROMU=false
 RUN promu build --cgo --prefix ./
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster global hub postgres exporter"


### PR DESCRIPTION
## Summary
- Pin runtime base from `ubi9/ubi-minimal:latest` to `ubi9/ubi-minimal:9.8-1779809423`
- Unblocks `stage-publish-globalhub-1-3-4-rc4` EC failure on `rpm_packages.unique_version`

## Context
`managed-7hcpb` / `stage-publish-globalhub-1-3-4-rc4` failed verify-conforma because
`postgres-exporter-globalhub-1-3` had mismatched RPMs across arches (arm64 glibc/gnutls
older than x86_64/ppc64le/s390x). Floating `:latest` likely caused arch builds to diverge.

## Test plan
- [ ] Konflux on-push for `postgres-exporter-globalhub-1-3` succeeds
- [ ] New image passes EC `rpm_packages.unique_version`
- [ ] Bundle nudge/rebuild picks up new digest (step 2)

Made with [Cursor](https://cursor.com)