### PR TITLE
Update GH 5.0 CPE and version labels in Containerfile.konflux

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -12,14 +12,14 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-postgres-exporter-rhel9-container"
-LABEL cpe="cpe:/a:redhat:multicluster_globalhub:1.8::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_globalhub:5.0::el9"
 LABEL org.label-schema.vendor="Red Hat"
 LABEL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA"
 LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
 LABEL name="multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9"
-LABEL version="release-1.8"
+LABEL version="release-5.0"
 LABEL summary="multicluster global hub postgres exporter"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary
Update image `cpe` and `version` labels from GH 1.8 to GH 5.0 on `release-5.0`.

## Why
Konflux stage publish (`stage-publish-globalhub-5-0`) failed `check-labels` / `enforce-cpe-label`:
built images had `cpe:/a:redhat:multicluster_globalhub:1.8::el9` but the 5.0 stage RPA requires `cpe:/a:redhat:multicluster_globalhub:5.0::el9`.

## Test plan
- [ ] Merge to `release-5.0` and wait for Konflux rebuild
- [ ] New snapshot passes stage publish `check-labels`