### PR TITLE
ACM-32443: onboard postgres_exporter to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md — postgres_exporter
+
+AI assistant context for **postgres_exporter** — the Red Hat fork of the Prometheus Community PostgreSQL Server Exporter, packaged for Multicluster Global Hub to expose database metrics for monitoring.
+
+Onboarded per [Fleet Engineering Agentic SDLC — repo onboarding](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md). Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).
+
+---
+
+## Build, Test, and Lint Commands
+
+```bash
+# Build the binary (uses promu)
+make build
+
+# Run unit tests
+make test
+
+# Run only short tests (no live PostgreSQL required)
+make common-test-short
+
+# Lint (golangci-lint)
+make lint
+
+# Check formatting
+make style
+
+# All checks + build + test (CI equivalent)
+make common-all
+
+# Konflux / production container image
+podman build -f Containerfile.konflux -t postgres-exporter:local .
+```
+
+> Konflux builds use `Containerfile.konflux`: builds `promu` from source with `CGO_ENABLED=1`, then calls `promu build --cgo` to produce the exporter binary with CGO support for FIPS compliance. Published multi-arch images via `.tekton/`.
+
+---
+
+## Repo Layout
+
+```text
+Containerfile.konflux         Production multi-stage container build (Konflux / brew)
+Makefile                      Thin wrapper — sets DOCKER_ARCHS/REPO, includes Makefile.common
+Makefile.common               Prometheus-community shared build rules (promu, lint, test, style)
+.tekton/                      Konflux PipelineRuns (push + pull-request for release-5.0)
+cmd/postgres_exporter/        Exporter main package
+collector/                    Metric collectors for PostgreSQL subsystems
+config/                       Config file parser and examples (auth_modules)
+postgres_mixin/               Grafana dashboards and alerting rules (upstream)
+promu/                        Build-tool source vendored for hermetic Konflux builds
+```
+
+---
+
+## Architecture
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for Global Hub integration, deployment context, Konflux CI, and configuration details.
+
+Upstream Prometheus Community docs remain in [README.md](README.md).
+
+---
+
+## Personal Config
+
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key. If the file does not exist, fall back to Claude memory (`user-config`), then placeholders. Run `make personalize` in [OpenShift-Fleet/agentic-sdlc](https://github.com/OpenShift-Fleet/agentic-sdlc) to generate it.
+
+---
+
+## Fleet Engineering Skills
+
+Use the Fleet plugin in Claude Code (`make install-claude` in agentic-sdlc) when available. In Cursor or other agents without the plugin, fetch and apply the relevant skill URL when the task matches its domain.
+
+| Skill | When to use |
+| ----- | ----------- |
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Begin work on a Jira ticket — creates sub-task, transitions status |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | Review a GitHub PR with worktree isolation and inline comments |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | Triage, search, link, or transition Jira issues |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Create a well-structured bug report with reproduction steps |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | Create a user story with acceptance criteria |

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- bjoydeep
+- birsanv
+
+reviewers:
+- bjoydeep
+- birsanv

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Architecture — postgres_exporter (Global Hub)
+
+**postgres_exporter** is a Red Hat–maintained fork of the [Prometheus Community PostgreSQL Server Exporter](https://github.com/prometheus-community/postgres_exporter), packaged for Multicluster Global Hub. The Global Hub **operator** deploys this image on the global hub cluster alongside PostgreSQL to expose database metrics in Prometheus format.
+
+Related: [multicluster-global-hub docs/ARCHITECTURE.md](https://github.com/stolostron/multicluster-global-hub/blob/release-5.0/docs/ARCHITECTURE.md) for the full operator/manager/agent data flow.
+
+---
+
+## Role in Global Hub
+
+| Aspect | Detail |
+| ------ | ------ |
+| **Deployed by** | `MulticlusterGlobalHub` operator reconciler |
+| **Runs on** | Global hub cluster, namespace `multicluster-global-hub` |
+| **Data source** | PostgreSQL (`multicluster-global-hub-postgresql`) — configured via `DATA_SOURCE_NAME` env var |
+| **Metrics endpoint** | `:9187/metrics` (Prometheus scrape target) |
+| **User** | `nobody` (unprivileged, rootless container) |
+| **Image** | `registry.redhat.io/multicluster-globalhub/multicluster-globalhub-postgres-exporter-rhel9` (prod) / Konflux dev workload quay path |
+
+The exporter is **read-only** — it issues `SELECT` queries against PostgreSQL system catalogs and `pg_stat_*` views. It does not write to the database or participate in the spec/status sync data flow.
+
+---
+
+## ACM Customizations
+
+This fork has **no source-code patches** on top of upstream. All customizations are in the build and packaging layer:
+
+- **CGO enabled**: `promu build --cgo` produces a CGO binary required for Konflux FIPS binary scanning (`fbc-fips-check-oci-ta`).
+- **promu vendored**: The `promu/` directory vendors the Prometheus build utility source so Konflux hermetic builds do not need external network access during compilation.
+- **UBI-minimal runtime**: Production image uses `registry.access.redhat.com/ubi9/ubi-minimal` for Red Hat supply-chain compliance.
+- **Red Hat labels**: Component `multicluster-globalhub-postgres-exporter-rhel9-container`, CPE `cpe:/a:redhat:multicluster_globalhub:5.0::el9`.
+
+---
+
+## Container Image
+
+`Containerfile.konflux` is a two-stage build:
+
+1. **Builder** — `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25`:
+   - Builds `promu` from source with `CGO_ENABLED=1`.
+   - Runs `promu build --cgo` to produce the `postgres_exporter` binary.
+2. **Runtime** — `registry.access.redhat.com/ubi9/ubi-minimal`:
+   - Copies `/workspace/postgres_exporter` to `/bin/postgres_exporter`.
+   - Runs as `nobody`, exposes port `9187`.
+
+Local build:
+
+```bash
+podman build -f Containerfile.konflux -t postgres-exporter:local .
+```
+
+---
+
+## CI/CD (Konflux)
+
+| Pipeline | Trigger | File |
+| -------- | ------- | ---- |
+| Push | `release-5.0` branch push | `.tekton/postgres-exporter-globalhub-5-0-push.yaml` |
+| Pull request | PRs to `release-5.0` | `.tekton/postgres-exporter-globalhub-5-0-pull-request.yaml` |
+
+- **Application:** `release-globalhub-5-0`
+- **Component:** `postgres-exporter-globalhub-5-0`
+- **Output:** `quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-0:<sha>`
+- **Platforms:** linux/x86_64, ppc64le, s390x, arm64
+- **Pipeline:** `konflux-build-catalog/pipelines/common-base.yaml` (hermetic, prefetch gomod for `promu/`)
+
+---
+
+## Configuration
+
+The exporter is configured via:
+
+| Method | Detail |
+| ------ | ------ |
+| `DATA_SOURCE_NAME` env var | PostgreSQL DSN — `postgresql://user:pass@host:5432/dbname?sslmode=disable` |
+| `--config.file` flag | YAML config with `auth_modules` for multi-target scraping |
+| `--collector.*` flags | Enable/disable individual metric collectors |
+
+Key collectors active by default:
+
+- `collector.database` — per-database stats
+- `collector.locks` — lock counts by mode
+- `collector.replication` — replication lag and slot state
+- `collector.stat_bgwriter` — background writer activity
+- `collector.stat_user_tables` — table-level I/O and vacuum stats
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose |
+| ------ | ------- |
+| `release-5.0` | Current Global Hub 5.0 development and Konflux builds |
+| `release-2.x` | Prior GH release tracks (maintenance; `release-2.17` = GH 1.8, `release-2.16` = GH 1.7, etc.) |
+
+The branch naming follows the ACM release numbering (`release-2.17` = ACM 2.17 = GH 1.8), not the upstream postgres_exporter version.
+
+---
+
+## Dependency Management
+
+The repo uses standard Go modules (`go.mod` / `go.sum`). Dependency updates are managed by **Mintmaker** (Konflux bot) which opens PRs against each active release branch. Mintmaker uses `fix(deps)` for security-relevant bumps and `chore(deps)` for routine updates. All Mintmaker PRs carry `do-not-merge/hold` and require human review before merge.


### PR DESCRIPTION
## Summary

Fixes: [ACM-32443](https://redhat.atlassian.net/browse/ACM-32443)

Onboards **postgres_exporter** to the Fleet Engineering Agentic SDLC per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md).

- Adds `CLAUDE.md` with verified build/test commands, repo layout, personal config lookup (`make personalize`), and Fleet Engineering skills catalog (URL fallback for Cursor / agents without the plugin)
- Adds `docs/ARCHITECTURE.md` covering Global Hub integration, role of the exporter alongside PostgreSQL, CGO/FIPS build details, Konflux CI on `release-5.0`, configuration, and branch strategy

## Onboarding checklist

Per [repo-onboarding.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/repo-onboarding.md):

- [x] `CLAUDE.md` — build/lint/test commands verified against `Makefile`, `Makefile.common`, and `Containerfile.konflux`
- [x] Personal config lookup with `make personalize` reference
- [x] `docs/ARCHITECTURE.md` created and linked (Global Hub deployment, FIPS/CGO build, Konflux CI)
- [x] Fleet Engineering skills URL table (for non-plugin environments)
- [ ] `make personalize` / `make install-claude` — operator setup (outside this PR)
- [ ] First `/start-work` session — post-merge validation

## Context

Third in the ACM-32443 onboarding series for Global Hub repos:
- stolostron/multicluster-global-hub#2512 ✓ merged
- stolostron/glo-grafana#281 ✓ merged
- **This PR** — postgres_exporter

Closes #101 (supersedes the stale Sep 2025 CLAUDE.md PR targeting `release-2.15`).

Day-to-day workflow: [ai-dev-workflow.md](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/practices/ai-dev-workflow.md).

## Test plan

- [x] Docs-only change — no code or CI target changes
- [x] `CLAUDE.md` repo-layout fence uses `text` language tag (MD040)
- [x] Build/test commands spot-checked against `Makefile`, `Makefile.common`, and `Containerfile.konflux`

[ACM-32443]: https://redhat.atlassian.net/browse/ACM-32443

Made with [Cursor](https://cursor.com)