### PR TITLE
chore: force postgres-exporter rebuild for conforma stage release

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,3 +1,4 @@
+# rebuild: force new image digest for conforma stage release (2026-06-26)
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Touch `Containerfile.konflux` to force a new image digest for `postgres-exporter-globalhub-5-0`
- Empty commit `0754a17` rebuilt but promoted the same digest (`sha256:5f5524b9…`) as the last Succeeded stage release — pre-flight still shows postgres-exporter as `same`

## Test plan
- [ ] Merge → `postgres-exporter-globalhub-5-0-on-push` succeeds on Konflux
- [ ] `lastPromotedImage` digest changes vs `5f5524b93…`
- [ ] MintMaker bundle nudge updates `konflux-patch.sh`

Made with [Cursor](https://cursor.com)