### PR TITLE
ACM-36289: Bump Go toolchain to 1.26.3 for GH 1.7

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Fixes: [ACM-36289](https://redhat.atlassian.net/browse/ACM-36289)

## Summary
- Bump `go` directive to **1.26.3** in `go.mod`
- Switch `Containerfile.konflux` builder to `openshift-golang-builder:rhel_9_1.26`

## Why
Align GH 1.7 postgres-exporter operand with Go 1.26 builder (1.26.3) for Konflux hermetic builds (same as [#226](https://github.com/stolostron/postgres_exporter/pull/226) for 5.0).

## Test plan
- [ ] Konflux `postgres-exporter-globalhub-1-7` PR build succeeds

Made with [Cursor](https://cursor.com)

[ACM-36289]: https://redhat.atlassian.net/browse/ACM-36289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ