### PR TITLE
Bump Go to 1.26.3 for GH 1.4 z-stream [multicluster-globalhub-1.4]

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     # This must match .circle/config.yml.
-    version: 1.25
+    version: 1.26
 repository:
     path: github.com/prometheus-community/postgres_exporter
 build:

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.3**
- Update `Containerfile.konflux` builder to `rhel_9_1.26`

## Why

Companion to multicluster-global-hub Go 1.26.3 bump for Global Hub **1.4** z-stream on `release-2.13`. Follows [#227](https://github.com/stolostron/postgres_exporter/pull/227) pattern from GH 1.7.

## Test plan

- [ ] Konflux build on `release-2.13` succeeds after merge

Made with Cursor

Made with [Cursor](https://cursor.com)