### PR TITLE
Add OWNERS to release-2.13 for prow /approve

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- bjoydeep
+- birsanv
+
+reviewers:
+- bjoydeep
+- birsanv


### PR DESCRIPTION
## Summary

- Add `OWNERS` to `release-2.13` (same approvers/reviewers as `release-2.14+`)
- Unblocks openshift-ci `/approve` on PRs targeting this branch (e.g. #228)

## Why

`release-2.13` is the only release branch missing `OWNERS`. openshift-ci reported `"approvers":[]` on #228, so bjoydeep's `/approve` did not add the `approved` label even though the GitHub review was APPROVED.

## Test plan

- [ ] Merge this PR
- [ ] On #228, comment `/approve` (or re-request approval) — `approved` label should appear

Made with Cursor

Made with [Cursor](https://cursor.com)