### PR TITLE
Bump Go to 1.26.4 for GH 1.4 z-stream [multicluster-globalhub-1.4]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.4**

## Why

Companion to multicluster-global-hub [ACM-36273](https://redhat.atlassian.net/browse/ACM-36273) / CVE-2026-27145 (crypto/x509 DNS SAN DoS) for Global Hub **1.4** z-stream on `release-2.13`. Follows [#228](https://github.com/stolostron/postgres_exporter/pull/228) (1.26.3) pattern.

## Test plan

- [ ] Konflux build on `release-2.13` succeeds after merge


Made with [Cursor](https://cursor.com)

[ACM-36273]: https://redhat.atlassian.net/browse/ACM-36273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ