### PR TITLE
Bump Go to 1.26.4 for GH 1.6 z-stream [multicluster-globalhub-1.6]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.4**

## Why

Companion to multicluster-global-hub [ACM-36275](https://redhat.atlassian.net/browse/ACM-36275) / CVE-2026-27145 for Global Hub **1.6** z-stream on `release-2.15`.

## Test plan

- [ ] Konflux build on `release-2.15` succeeds after merge


Made with [Cursor](https://cursor.com)

[ACM-36275]: https://redhat.atlassian.net/browse/ACM-36275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ