### PR TITLE
Bump Go to 1.26.4 for GH 1.7 z-stream [multicluster-globalhub-1.7]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.4**

## Why

Companion to multicluster-global-hub [ACM-36276](https://redhat.atlassian.net/browse/ACM-36276) / CVE-2026-27145 for Global Hub **1.7** z-stream on `release-2.16`.

## Test plan

- [ ] Konflux build on `release-2.16` succeeds after merge


Made with [Cursor](https://cursor.com)

[ACM-36276]: https://redhat.atlassian.net/browse/ACM-36276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ