### PR TITLE
Bump Go to 1.26.4 for GH 5.0 z-stream [multicluster-globalhub-5.0]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary

- Bump `go.mod` to **1.26.4** on `release-5.0`

## Why

Companion to multicluster-global-hub [#2634](https://github.com/stolostron/multicluster-global-hub/pull/2634) and z-stream ACM-36273–36277 fixes for CVE-2026-27145. Follows [#226](https://github.com/stolostron/postgres_exporter/pull/226) (1.26.3) pattern.

## Test plan

- [ ] Konflux build on `release-5.0` succeeds after merge


Made with [Cursor](https://cursor.com)