### PR TITLE
Add rohit-bharmal to OWNERS (release-2.17 backport)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,10 @@
 approvers:
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - bjoydeep
 - birsanv
+- rohit-bharmal
 


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `approvers` and `reviewers` in `OWNERS` (same pattern as `birsanv`).

## Test plan
- [ ] `/lgtm` from existing approver