### PR TITLE
Add rohit-bharmal to OWNERS (release-2.13 backport)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,9 @@
 approvers:
 - bjoydeep
 - birsanv
+- rohit-bharmal
 
 reviewers:
 - bjoydeep
 - birsanv
+- rohit-bharmal


### PR DESCRIPTION
## Summary
- Add `rohit-bharmal` to `approvers` and `reviewers` in `OWNERS` (same pattern as `birsanv`).

## Test plan
- [ ] `/lgtm` from existing approver