### PR TITLE
ACM-40739: add Konflux Tekton pipelines for postgres-exporter globalhub-5-1

### DIFF
--- a/.tekton/postgres-exporter-globalhub-5-1-pull-request.yaml
+++ b/.tekton/postgres-exporter-globalhub-5-1-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/postgres_exporter?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-5.1"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-1
+    appstudio.openshift.io/component: postgres-exporter-globalhub-5-1
+    pipelines.appstudio.openshift.io/type: build
+  name: postgres-exporter-globalhub-5-1-on-pull-request
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-1:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: Containerfile.konflux
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "gomod", "path": "./promu"} ]'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-postgres-exporter-globalhub-5-1
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/postgres-exporter-globalhub-5-1-push.yaml
+++ b/.tekton/postgres-exporter-globalhub-5-1-push.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/build-nudge-files: "konflux-patch.sh"
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/postgres_exporter?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-5.1"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-globalhub-5-1
+    appstudio.openshift.io/component: postgres-exporter-globalhub-5-1
+    pipelines.appstudio.openshift.io/type: build
+  name: postgres-exporter-globalhub-5-1-on-push
+  namespace: acm-multicluster-glo-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/acm-multicluster-glo-tenant/postgres-exporter-globalhub-5-1:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
+  - name: dockerfile
+    value: Containerfile.konflux
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[ {"type": "gomod", "path": "."}, {"type": "gomod", "path": "./promu"} ]'
+  - name: send-slack-notification
+    value: "true"
+  - name: konflux-application-name
+    value: "release-globalhub-5-1"
+  - name: slack-webhook-url-secret-name
+    value: "slack-notify-webhook"
+  - name: slack-webhook-url-secret-key
+    value: "slack-webhook-url"
+  - name: slack-group-id
+    value: "S09JCE3DF9N"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common-base.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-postgres-exporter-globalhub-5-1
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,5 +1,5 @@
 # rebuild: force new image digest for conforma stage release (2026-06-26)
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/postgres_exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Related: [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739)

## Summary

- Add `.tekton/postgres-exporter-globalhub-5-1-{push,pull-request}.yaml` for Konflux builds on `release-5.1`
- Targets application `release-globalhub-5-1`, component `postgres-exporter-globalhub-5-1`

## Context
Phase 1 of [ACM-40739](https://redhat.atlassian.net/browse/ACM-40739).

## Test plan
- [ ] Konflux on-push runs after merge to `release-5.1`

Made with [Cursor](https://cursor.com)

[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-40739]: https://redhat.atlassian.net/browse/ACM-40739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ