### PR TITLE
ACM-41559: Switch to PQC-enabled base image for postgres-exporter

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -8,7 +8,7 @@ ENV BUILD_PROMU=false
 RUN promu build --cgo --prefix ./
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-postgres-exporter-rhel9-container"


### PR DESCRIPTION
## Summary
- Switch runtime base image from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` for the postgres-exporter component
- Enables Post-Quantum Cryptography (PQC) in OpenSSL as required by [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663) / [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for ACM 5.0

## Changes

| File | Change |
|------|--------|
| `Containerfile.konflux` | `ubi9/ubi-minimal:latest` → `ubi9/ubi-minimal-pqc:latest` |

## Test plan
- [ ] Konflux build passes with new PQC base image
- [ ] No regression in regular mode
- [ ] No regression in FIPS mode

## Related
- Jira: [ACM-41559](https://redhat.atlassian.net/browse/ACM-41559)
- Parent Epic: [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663)
- Companion PRs: [multicluster-global-hub#2751](https://github.com/stolostron/multicluster-global-hub/pull/2751), [glo-grafana#467](https://github.com/stolostron/glo-grafana/pull/467)

[ACM-40663]: https://redhat.atlassian.net/browse/ACM-40663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPSTRAT-3113]: https://redhat.atlassian.net/browse/OCPSTRAT-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41559]: https://redhat.atlassian.net/browse/ACM-41559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-40663]: https://redhat.atlassian.net/browse/ACM-40663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ