### PR TITLE
ACM-41559: Switch to PQC-enabled base image

### DIFF
--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -9,7 +9,7 @@ ENV BUILD_PROMU=false
 RUN promu build --cgo --prefix ./
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # Red Hat annotations.
 LABEL com.redhat.component="multicluster-globalhub-postgres-exporter-rhel9-container"


### PR DESCRIPTION
## Summary
- Switch base image from `registry.access.redhat.com/ubi9/ubi-minimal:latest` to `registry.redhat.io/ubi9/ubi-minimal-pqc:latest` in `Containerfile.konflux`
- Required for post-quantum cryptography (PQC) compliance

## Jira
https://redhat.atlassian.net/browse/ACM-41559